### PR TITLE
Implement HttpClientRequester

### DIFF
--- a/AngleSharp.Io.Tests/AngleSharp.Io.Tests.csproj
+++ b/AngleSharp.Io.Tests/AngleSharp.Io.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AngleSharp.Io.Tests</RootNamespace>
     <AssemblyName>AngleSharp.Io.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -40,6 +40,14 @@
       <HintPath>..\packages\AngleSharp.0.9.2\lib\net45\AngleSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FluentAssertions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
@@ -65,6 +73,9 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -81,6 +92,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helper.cs" />
+    <Compile Include="Network\HttpClientRequesterTests.cs" />
+    <Compile Include="Network\ResponseTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/AngleSharp.Io.Tests/Helper.cs
+++ b/AngleSharp.Io.Tests/Helper.cs
@@ -1,9 +1,9 @@
-﻿namespace AngleSharp.Core.Tests
+﻿namespace AngleSharp.Io.Tests
 {
-    using NUnit.Framework;
     using System;
     using System.IO;
     using System.Net.NetworkInformation;
+    using NUnit.Framework;
 
     /// <summary>
     /// Small (but quite useable) code to enable / disable some
@@ -39,7 +39,7 @@
             if (!NetworkInterface.GetIsNetworkAvailable())
                 return false;
 
-            foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces())
+            foreach (var ni in NetworkInterface.GetAllNetworkInterfaces())
             {
                 // discard because of standard reasons
                 if ((ni.OperationalStatus != OperationalStatus.Up) ||

--- a/AngleSharp.Io.Tests/Helper.cs
+++ b/AngleSharp.Io.Tests/Helper.cs
@@ -1,0 +1,87 @@
+﻿namespace AngleSharp.Core.Tests
+{
+    using NUnit.Framework;
+    using System;
+    using System.IO;
+    using System.Net.NetworkInformation;
+
+    /// <summary>
+    /// Small (but quite useable) code to enable / disable some
+    /// test(s) depending on the current network status.
+    /// Taken from
+    /// http://stackoverflow.com/questions/520347/c-sharp-how-do-i-check-for-a-network-connection
+    /// </summary>
+    class Helper
+    {
+        /// <summary>
+        /// Indicates whether any network connection is available
+        /// Filter connections below a specified speed, as well as virtual network cards.
+        /// Additionally writes an inconclusive message if no network is available.
+        /// </summary>
+        /// <returns>True if a network connection is available; otherwise false.</returns>
+        public static Boolean IsNetworkAvailable()
+        {
+            if (IsNetworkAvailable(0))
+                return true;
+
+            Assert.Inconclusive("No network has been detected. Test skipped.");
+            return false;
+        }
+
+        /// <summary>
+        /// Indicates whether any network connection is available.
+        /// Filter connections below a specified speed, as well as virtual network cards.
+        /// </summary>
+        /// <param name="minimumSpeed">The minimum speed required. Passing 0 will not filter connection using speed.</param>
+        /// <returns>True if a network connection is available; otherwise false.</returns>
+        public static Boolean IsNetworkAvailable(Int64 minimumSpeed)
+        {
+            if (!NetworkInterface.GetIsNetworkAvailable())
+                return false;
+
+            foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                // discard because of standard reasons
+                if ((ni.OperationalStatus != OperationalStatus.Up) ||
+                    (ni.NetworkInterfaceType == NetworkInterfaceType.Loopback) ||
+                    (ni.NetworkInterfaceType == NetworkInterfaceType.Tunnel))
+                    continue;
+
+                // this allow to filter modems, serial, etc.
+                // I use 10000000 as a minimum speed for most cases
+                if (ni.Speed < minimumSpeed)
+                    continue;
+
+                // discard virtual cards (virtual box, virtual pc, etc.)
+                if ((ni.Description.IndexOf("virtual", StringComparison.OrdinalIgnoreCase) >= 0) ||
+                    (ni.Name.IndexOf("virtual", StringComparison.OrdinalIgnoreCase) >= 0))
+                    continue;
+
+                // discard "Microsoft Loopback Adapter", it will not show as NetworkInterfaceType.Loopback but as Ethernet Card.
+                if (ni.Description.Equals("Microsoft Loopback Adapter", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public static Stream StreamFromBytes(Byte[] content)
+        {
+            var stream = new MemoryStream(content);
+            stream.Position = 0;
+            return stream;
+        }
+
+        public static Stream StreamFromString(String s)
+        {
+            var stream = new MemoryStream();
+            var writer = new StreamWriter(stream);
+            writer.Write(s);
+            writer.Flush();
+            stream.Position = 0;
+            return stream;
+        }
+    }
+}

--- a/AngleSharp.Io.Tests/Helper.cs
+++ b/AngleSharp.Io.Tests/Helper.cs
@@ -66,22 +66,5 @@
 
             return false;
         }
-
-        public static Stream StreamFromBytes(Byte[] content)
-        {
-            var stream = new MemoryStream(content);
-            stream.Position = 0;
-            return stream;
-        }
-
-        public static Stream StreamFromString(String s)
-        {
-            var stream = new MemoryStream();
-            var writer = new StreamWriter(stream);
-            writer.Write(s);
-            writer.Flush();
-            stream.Position = 0;
-            return stream;
-        }
     }
 }

--- a/AngleSharp.Io.Tests/Network/HttpClientRequesterTests.cs
+++ b/AngleSharp.Io.Tests/Network/HttpClientRequesterTests.cs
@@ -1,0 +1,265 @@
+﻿namespace AngleSharp.Io.Tests.Network
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AngleSharp.Io.Network;
+    using AngleSharp.Network;
+    using AngleSharp.Services.Default;
+    using FluentAssertions;
+    using NUnit.Framework;
+    using NetHttpMethod = System.Net.Http.HttpMethod;
+    using AngleSharpHttpMethod = AngleSharp.Network.HttpMethod;
+
+
+    [TestFixture]
+    public class HttpClientRequesterTests
+    {
+        [Test]
+        public async Task RequestWithContent()
+        {
+            // ARRANGE
+            var ts = new TestState();
+
+            // ACT
+            await ts.Target.RequestAsync(ts.Request, CancellationToken.None);
+
+            // ASSERT
+            ts.HttpRequestMessage.Version.Should().Be(new Version(1, 1));
+            ts.HttpRequestMessage.Method.Should().Be(NetHttpMethod.Post);
+            ts.HttpRequestMessage.RequestUri.Should().Be(new Uri("http://example/path?query=value"));
+            Encoding.UTF8.GetString(ts.HttpRequestMessageContent).Should().Be("\"request\"");
+            ts.HttpRequestMessage.Content.Headers.Select(p => p.Key).ShouldBeEquivalentTo(new[] {"Content-Type", "Content-Length"});
+            ts.HttpRequestMessage.Content.Headers.ContentType.ToString().Should().Be("application/json");
+            ts.HttpRequestMessage.Content.Headers.ContentLength.Should().Be(9);
+            ts.HttpRequestMessage.Properties.Should().BeEmpty();
+            ts.HttpRequestMessage.Headers.Select(p => p.Key).ShouldBeEquivalentTo(new[] {"User-Agent", "Cookie"});
+            ts.HttpRequestMessage.Headers.UserAgent.ToString().Should().Be("Foo/2.0");
+            ts.HttpRequestMessage.Headers.Single(p => p.Key == "Cookie").Value.ShouldBeEquivalentTo(new[] {"foo=bar"});
+        }
+
+        [Test]
+        public async Task RequestWithoutContent()
+        {
+            // ARRANGE
+            var ts = new TestState {Request = {Content = null, Method = AngleSharpHttpMethod.Get}};
+
+            // ACT
+            await ts.Target.RequestAsync(ts.Request, CancellationToken.None);
+
+            // ASSERT
+            ts.HttpRequestMessage.Version.Should().Be(new Version(1, 1));
+            ts.HttpRequestMessage.Method.Should().Be(NetHttpMethod.Get);
+            ts.HttpRequestMessage.RequestUri.Should().Be(new Uri("http://example/path?query=value"));
+            ts.HttpRequestMessage.Content.Should().BeNull();
+            ts.HttpRequestMessage.Properties.Should().BeEmpty();
+            ts.HttpRequestMessage.Headers.Select(p => p.Key).ShouldBeEquivalentTo(new[] {"User-Agent", "Cookie"});
+            ts.HttpRequestMessage.Headers.UserAgent.ToString().Should().Be("Foo/2.0");
+            ts.HttpRequestMessage.Headers.Single(p => p.Key == "Cookie").Value.ShouldBeEquivalentTo(new[] {"foo=bar"});
+        }
+
+        [Test]
+        public async Task ResponseWithContent()
+        {
+            // ARRANGE
+            var ts = new TestState();
+
+            // ACT
+            var response = await ts.Target.RequestAsync(ts.Request, CancellationToken.None);
+
+            // ASSERT
+            response.Address.ShouldBeEquivalentTo(ts.Request.Address);
+            response.StatusCode.Should().Be(ts.HttpResponseMessage.StatusCode);
+            response.Headers.Keys.ShouldBeEquivalentTo(new[] {"Server", "X-Powered-By", "X-CSV", "Content-Type", "Content-Length"});
+            response.Headers["Server"].Should().Be("Fake");
+            response.Headers["X-Powered-By"].Should().Be("Magic");
+            response.Headers["X-CSV"].Should().Be("foo, bar");
+            response.Headers["Content-Type"].Should().Be("application/json; charset=utf-8");
+            response.Headers["Content-Length"].Should().Be("10");
+            new StreamReader(response.Content, Encoding.UTF8).ReadToEnd().Should().Be("\"response\"");
+        }
+
+        [Test]
+        public async Task ResponseWithoutContent()
+        {
+            // ARRANGE
+            var ts = new TestState {HttpResponseMessage = {Content = null}};
+
+            // ACT
+            var response = await ts.Target.RequestAsync(ts.Request, CancellationToken.None);
+
+            // ASSERT
+            response.Address.ShouldBeEquivalentTo(ts.Request.Address);
+            response.StatusCode.Should().Be(ts.HttpResponseMessage.StatusCode);
+            response.Headers.Keys.ShouldBeEquivalentTo(new[] {"Server", "X-Powered-By", "X-CSV"});
+            response.Headers["Server"].Should().Be("Fake");
+            response.Headers["X-Powered-By"].Should().Be("Magic");
+            response.Headers["X-CSV"].Should().Be("foo, bar");
+            response.Content.Should().BeNull();
+        }
+
+        [Test]
+        public void SupportsHttp()
+        {
+            // ARRANGE, ACT, ASSERT
+            new TestState().Target.SupportsProtocol("HTTP").Should().BeTrue();
+        }
+
+        [Test]
+        public void SupportsHttps()
+        {
+            // ARRANGE, ACT, ASSERT
+            new TestState().Target.SupportsProtocol("HTTPS").Should().BeTrue();
+        }
+
+        [Test]
+        public async Task EndToEnd()
+        {
+            if (Helper.IsNetworkAvailable())
+            {
+                // ARRANGE
+                var httpClient = new HttpClient();
+                var requester = new HttpClientRequester(httpClient);
+                var configuration = new Configuration(new[] { new LoaderService(new[] { requester }) });
+                var context = BrowsingContext.New(configuration);
+                var request = DocumentRequest.Get(Url.Create("http://httpbin.org/html"));
+
+                // ACT
+                var response = await context.Loader.LoadAsync(request, CancellationToken.None);
+                var document = await context.OpenAsync(response, CancellationToken.None);
+
+                // ASSERT
+                document.QuerySelector("h1").ToHtml().Should().Be("<h1>Herman Melville - Moby-Dick</h1>");
+            }
+        }
+
+        class TestState
+        {
+            public TestState()
+            {
+                // dependencies
+
+                TestHandler = new TestHandler(this);
+                HttpClient = new HttpClient(TestHandler);
+
+                // data
+                Request = new Request
+                {
+                    Method = AngleSharpHttpMethod.Post,
+                    Address = new Url("http://example/path?query=value"),
+                    Headers = new Dictionary<String, String>
+                    {
+                        {"User-Agent", "Foo/2.0"},
+                        {"Cookie", "foo=bar"},
+                        {"Content-Type", "application/json"},
+                        {"Content-Length", "9"}
+                    },
+                    Content = new MemoryStream(Encoding.UTF8.GetBytes("\"request\""))
+                };
+                HttpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("\"response\"", Encoding.UTF8, "application/json"),
+                    Headers =
+                    {
+                        {"Server", "Fake"},
+                        {"X-Powered-By", "Magic"},
+                        {"X-CSV", new[] {"foo", "bar"}}
+                    }
+                };
+
+                // setup
+                Target = new HttpClientRequester(HttpClient);
+            }
+
+            public Request Request
+            {
+                get;
+            }
+
+            public HttpClientRequester Target
+            {
+                get;
+            }
+
+            public HttpClient HttpClient
+            {
+                get;
+            }
+
+            public TestHandler TestHandler
+            {
+                get;
+            }
+
+            public HttpResponseMessage HttpResponseMessage
+            {
+                get;
+            }
+
+            public HttpRequestMessage HttpRequestMessage
+            {
+                get;
+                set;
+            }
+
+            public Byte[] HttpRequestMessageContent
+            {
+                get;
+                set;
+            }
+        }
+
+        class TestHandler : DelegatingHandler
+        {
+            readonly TestState _testState;
+
+            public TestHandler(TestState testState)
+            {
+                _testState = testState;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                _testState.HttpRequestMessage = request;
+                if (request.Content != null)
+                    _testState.HttpRequestMessageContent = await request.Content.ReadAsByteArrayAsync();
+
+                _testState.HttpResponseMessage.RequestMessage = request;
+                return _testState.HttpResponseMessage;
+            }
+        }
+
+        class Request : IRequest
+        {
+            public AngleSharpHttpMethod Method
+            {
+                get;
+                set;
+            }
+
+            public Url Address
+            {
+                get;
+                set;
+            }
+
+            public Dictionary<String, String> Headers
+            {
+                get;
+                set;
+            }
+
+            public Stream Content
+            {
+                get;
+                set;
+            }
+        }
+    }
+}

--- a/AngleSharp.Io.Tests/Network/ResponseTests.cs
+++ b/AngleSharp.Io.Tests/Network/ResponseTests.cs
@@ -1,7 +1,9 @@
 ﻿namespace AngleSharp.Io.Tests.Network
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
+    using System.Net;
     using AngleSharp.Io.Network;
     using FluentAssertions;
     using NUnit.Framework;
@@ -10,17 +12,40 @@
     public class ResponseTests
     {
         [Test]
-        public void DisposesContent()
+        public void Initialize()
+        {
+            // ARRANGE, ACT
+            var response = new Response();
+
+            // ASSERT
+            response.Content.Should().BeNull();
+            response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+            response.Headers.Should().NotBeNull();
+            response.Headers.Should().BeEmpty();
+            response.Address.Should().BeNull();
+        }
+
+        [Test]
+        public void DisposesContentAndHeaders()
         {
             // ARRANGE
             var stream = new DisposableStream();
-            var response = new Response {Content = stream};
+            var response = new Response
+            {
+                Content = stream,
+                Headers = new Dictionary<String, String>
+                {
+                    {"Server", "Fake"},
+                    {"X-Foo", "Bar"}
+                }
+            };
 
             // ACT
             response.Dispose();
 
             // ASSERT
             stream.Disposed.Should().BeTrue();
+            response.Headers.Should().BeEmpty();
         }
 
         [Test]
@@ -35,6 +60,7 @@
             // ASSERT
             action.ShouldNotThrow();
         }
+
         class DisposableStream : Stream
         {
             public override Boolean CanRead

--- a/AngleSharp.Io.Tests/Network/ResponseTests.cs
+++ b/AngleSharp.Io.Tests/Network/ResponseTests.cs
@@ -1,0 +1,104 @@
+﻿namespace AngleSharp.Io.Tests.Network
+{
+    using System;
+    using System.IO;
+    using AngleSharp.Io.Network;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ResponseTests
+    {
+        [Test]
+        public void DisposesContent()
+        {
+            // ARRANGE
+            var stream = new DisposableStream();
+            var response = new Response {Content = stream};
+
+            // ACT
+            response.Dispose();
+
+            // ASSERT
+            stream.Disposed.Should().BeTrue();
+        }
+
+        [Test]
+        public void DisposesNothingWhenContentIsNull()
+        {
+            // ARRANGE
+            var response = new Response {Content = null};
+
+            // ACT
+            Action action = () => response.Dispose();
+
+            // ASSERT
+            action.ShouldNotThrow();
+        }
+        class DisposableStream : Stream
+        {
+            public override Boolean CanRead
+            {
+                get;
+            }
+
+            public override Boolean CanSeek
+            {
+                get;
+            }
+
+            public override Boolean CanWrite
+            {
+                get;
+            }
+
+            public override Int64 Length
+            {
+                get;
+            }
+
+            public override Int64 Position
+            {
+                get;
+                set;
+            }
+
+            public Boolean Disposed
+            {
+                get;
+                set;
+            }
+
+            public override void Flush()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Int64 Seek(Int64 offset, SeekOrigin origin)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void SetLength(Int64 value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Int32 Read(Byte[] buffer, Int32 offset, Int32 count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Write(Byte[] buffer, Int32 offset, Int32 count)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override void Dispose(Boolean disposing)
+            {
+                Disposed = true;
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/AngleSharp.Io.Tests/packages.config
+++ b/AngleSharp.Io.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AngleSharp" version="0.9.2" targetFramework="net46" />
+  <package id="FluentAssertions" version="4.0.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net46" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net46" />
 </packages>

--- a/AngleSharp.Io/AngleSharp.Io.csproj
+++ b/AngleSharp.Io/AngleSharp.Io.csproj
@@ -35,6 +35,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -42,6 +43,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Network\HttpClientRequester.cs" />
+    <Compile Include="Network\Response.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/AngleSharp.Io/Network/HttpClientRequester.cs
+++ b/AngleSharp.Io/Network/HttpClientRequester.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using AngleSharp;
+using AngleSharp.Network;
+using HttpMethod = System.Net.Http.HttpMethod;
+
+namespace Knapcode.AngleSharp.NetHttp
+{
+    public class HttpClientRequester : IRequester
+    {
+        private readonly HttpClient _client;
+
+        public HttpClientRequester(HttpClient client)
+        {
+            _client = client;
+        }
+
+        public bool SupportsProtocol(string protocol)
+        {
+            return protocol.Equals("http", StringComparison.OrdinalIgnoreCase) || protocol.Equals("https", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public async Task<IResponse> RequestAsync(IRequest request, CancellationToken cancellationToken)
+        {
+            // create the request message
+            var method = new HttpMethod(request.Method.ToString().ToUpper());
+            var requestMessage = new HttpRequestMessage(method, request.Address);
+            var contentHeaders = new List<KeyValuePair<string, string>>();
+            foreach (var header in request.Headers)
+            {
+                // Source:
+                // https://github.com/aspnet/Mvc/blob/02c36a1c4824936682b26b6c133d11bebee822a2/src/Microsoft.AspNet.Mvc.WebApiCompatShim/HttpRequestMessage/HttpRequestMessageFeature.cs
+                if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value))
+                {
+                    contentHeaders.Add(new KeyValuePair<string, string>(header.Key, header.Value));
+                }
+            }
+
+            // set up the content
+            if (request.Content != null && method != HttpMethod.Get && method != HttpMethod.Head)
+            {
+                requestMessage.Content = new StreamContent(request.Content);
+                foreach (var header in contentHeaders)
+                {
+                    requestMessage.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+
+            // execute the request
+            var responseMessage = await _client.SendAsync(requestMessage, cancellationToken);
+
+            // convert the response
+            var response = new Response
+            {
+                Headers = responseMessage.Headers.ToDictionary(p => p.Key, p => string.Join(", ", p.Value)),
+                Address = Url.Convert(responseMessage.RequestMessage.RequestUri),
+                StatusCode = responseMessage.StatusCode
+            };
+
+            if (responseMessage.Content != null)
+            {
+                response.Content = await responseMessage.Content.ReadAsStreamAsync();
+                foreach (var pair in responseMessage.Content.Headers)
+                {
+                    response.Headers[pair.Key] = string.Join(", ", pair.Value);
+                }
+            }
+
+            return response;
+        }
+    }
+}

--- a/AngleSharp.Io/Network/HttpClientRequester.cs
+++ b/AngleSharp.Io/Network/HttpClientRequester.cs
@@ -1,15 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using AngleSharp;
-using AngleSharp.Network;
-using HttpMethod = System.Net.Http.HttpMethod;
-
-namespace Knapcode.AngleSharp.NetHttp
+﻿namespace AngleSharp.Io.Network
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AngleSharp.Network;
+    using HttpMethod = System.Net.Http.HttpMethod;
+
     public class HttpClientRequester : IRequester
     {
         private readonly HttpClient _client;

--- a/AngleSharp.Io/Network/HttpClientRequester.cs
+++ b/AngleSharp.Io/Network/HttpClientRequester.cs
@@ -11,14 +11,14 @@
 
     public class HttpClientRequester : IRequester
     {
-        private readonly HttpClient _client;
+        readonly HttpClient _client;
 
         public HttpClientRequester(HttpClient client)
         {
             _client = client;
         }
 
-        public bool SupportsProtocol(string protocol)
+        public Boolean SupportsProtocol(String protocol)
         {
             return protocol.Equals("http", StringComparison.OrdinalIgnoreCase) || protocol.Equals("https", StringComparison.OrdinalIgnoreCase);
         }
@@ -28,15 +28,13 @@
             // create the request message
             var method = new HttpMethod(request.Method.ToString().ToUpper());
             var requestMessage = new HttpRequestMessage(method, request.Address);
-            var contentHeaders = new List<KeyValuePair<string, string>>();
+            var contentHeaders = new List<KeyValuePair<String, String>>();
             foreach (var header in request.Headers)
             {
                 // Source:
                 // https://github.com/aspnet/Mvc/blob/02c36a1c4824936682b26b6c133d11bebee822a2/src/Microsoft.AspNet.Mvc.WebApiCompatShim/HttpRequestMessage/HttpRequestMessageFeature.cs
                 if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value))
-                {
-                    contentHeaders.Add(new KeyValuePair<string, string>(header.Key, header.Value));
-                }
+                    contentHeaders.Add(new KeyValuePair<String, String>(header.Key, header.Value));
             }
 
             // set up the content
@@ -44,9 +42,7 @@
             {
                 requestMessage.Content = new StreamContent(request.Content);
                 foreach (var header in contentHeaders)
-                {
                     requestMessage.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
-                }
             }
 
             // execute the request
@@ -55,7 +51,7 @@
             // convert the response
             var response = new Response
             {
-                Headers = responseMessage.Headers.ToDictionary(p => p.Key, p => string.Join(", ", p.Value)),
+                Headers = responseMessage.Headers.ToDictionary(p => p.Key, p => String.Join(", ", p.Value)),
                 Address = Url.Convert(responseMessage.RequestMessage.RequestUri),
                 StatusCode = responseMessage.StatusCode
             };
@@ -64,9 +60,7 @@
             {
                 response.Content = await responseMessage.Content.ReadAsStreamAsync();
                 foreach (var pair in responseMessage.Content.Headers)
-                {
-                    response.Headers[pair.Key] = string.Join(", ", pair.Value);
-                }
+                    response.Headers[pair.Key] = String.Join(", ", pair.Value);
             }
 
             return response;

--- a/AngleSharp.Io/Network/HttpClientRequester.cs
+++ b/AngleSharp.Io/Network/HttpClientRequester.cs
@@ -42,11 +42,12 @@
         /// <summary>
         /// Performs an asynchronous request that can be cancelled.
         /// </summary>
-        /// <param name="request">The options to consider.</param><param name="cancel">The token for cancelling the task.</param>
+        /// <param name="request">The options to consider.</param>
+        /// <param name="cancel">The token for cancelling the task.</param>
         /// <returns>
         /// The task that will eventually give the response data.
         /// </returns>
-        public async Task<IResponse> RequestAsync(IRequest request, CancellationToken cancellationToken)
+        public async Task<IResponse> RequestAsync(IRequest request, CancellationToken cancel)
         {
             // create the request message
             var method = new HttpMethod(request.Method.ToString().ToUpper());
@@ -69,7 +70,7 @@
             }
 
             // execute the request
-            var responseMessage = await _client.SendAsync(requestMessage, cancellationToken);
+            var responseMessage = await _client.SendAsync(requestMessage, cancel);
 
             // convert the response
             var response = new Response

--- a/AngleSharp.Io/Network/HttpClientRequester.cs
+++ b/AngleSharp.Io/Network/HttpClientRequester.cs
@@ -9,20 +9,43 @@
     using AngleSharp.Network;
     using HttpMethod = System.Net.Http.HttpMethod;
 
+    /// <summary>
+    /// An HTTP requester based on <see cref="HttpClient"/>.
+    /// </summary>
     public class HttpClientRequester : IRequester
     {
         readonly HttpClient _client;
 
+        /// <summary>
+        /// Creates a new HTTP client request.
+        /// </summary>
+        /// <param name="client">The HTTP client to use for requests.</param>
         public HttpClientRequester(HttpClient client)
         {
             _client = client;
         }
 
+        /// <summary>
+        /// Checks if the given protocol is supported.
+        /// </summary>
+        /// <param name="protocol">
+        /// The protocol to check for, e.g. http.
+        /// </param>
+        /// <returns>
+        /// True if the protocol is supported, otherwise false.
+        /// </returns>
         public Boolean SupportsProtocol(String protocol)
         {
             return protocol.Equals("http", StringComparison.OrdinalIgnoreCase) || protocol.Equals("https", StringComparison.OrdinalIgnoreCase);
         }
 
+        /// <summary>
+        /// Performs an asynchronous request that can be cancelled.
+        /// </summary>
+        /// <param name="request">The options to consider.</param><param name="cancel">The token for cancelling the task.</param>
+        /// <returns>
+        /// The task that will eventually give the response data.
+        /// </returns>
         public async Task<IResponse> RequestAsync(IRequest request, CancellationToken cancellationToken)
         {
             // create the request message

--- a/AngleSharp.Io/Network/Response.cs
+++ b/AngleSharp.Io/Network/Response.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using AngleSharp;
+using AngleSharp.Network;
+
+namespace Knapcode.AngleSharp.NetHttp
+{
+    public class Response : IResponse
+    {
+        public void Dispose()
+        {
+            if (Content != null)
+            {
+                Content.Dispose();
+            }
+        }
+
+        public HttpStatusCode StatusCode { get; set; }
+
+        public Url Address { get; set; }
+
+        public IDictionary<string, string> Headers { get; set; }
+
+        public Stream Content { get; set; }
+    }
+}

--- a/AngleSharp.Io/Network/Response.cs
+++ b/AngleSharp.Io/Network/Response.cs
@@ -1,27 +1,79 @@
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using AngleSharp;
-using AngleSharp.Network;
-
-namespace Knapcode.AngleSharp.NetHttp
+namespace AngleSharp.Io.Network
 {
-    public class Response : IResponse
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net;
+    using AngleSharp.Network;
+
+    /// <summary>
+    /// The default HTTP response encapsulation object.
+    /// </summary>
+    sealed class Response : IResponse
     {
+        #region ctor
+
+        /// <summary>
+        /// Creates a new default response object.
+        /// </summary>
+        public Response()
+        {
+            Headers = new Dictionary<String, String>(StringComparer.OrdinalIgnoreCase);
+            StatusCode = HttpStatusCode.Accepted;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the status code of the response.
+        /// </summary>
+        public HttpStatusCode StatusCode
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the url of the response.
+        /// </summary>
+        public Url Address
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the headers (key-value pairs) of the response.
+        /// </summary>
+        public IDictionary<String, String> Headers
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets a stream for content of the response.
+        /// </summary>
+        public Stream Content
+        {
+            get;
+            set;
+        }
+
+        #endregion
+
+        #region Methods
+
         public void Dispose()
         {
             if (Content != null)
-            {
                 Content.Dispose();
-            }
+
+            Headers.Clear();
         }
 
-        public HttpStatusCode StatusCode { get; set; }
-
-        public Url Address { get; set; }
-
-        public IDictionary<string, string> Headers { get; set; }
-
-        public Stream Content { get; set; }
+        #endregion
     }
 }


### PR DESCRIPTION
Per issue #1. A couple questions for you, @FlorianRappl.

1. For `Response`, there is already an internal implementation in AngleSharp... I just copied it. Would it be better to make AngleSharp.Io a [friend assembly](https://msdn.microsoft.com/en-us/library/system.runtime.compilerservices.internalsvisibletoattribute%28v=vs.110%29.aspx) of AngleSharp so AngleSharp.Io can use internal stuff? Another thing I'd like to reference is `KnownProtocols`.

2. I copied over the `Helper` class for the test project. Is code duplication fine in this case.

3. Are you going to create a nuspec for AngleSharp.Io and publish it to nuget.org?

4. I tried to match the style of AngleSharp but I'm not sure if I got everything right. Feel free to nitpick like crazy.