### PR TITLE
IConfiguration.WithHttpRequesters(HttpMessageHandler)

### DIFF
--- a/AngleSharp.Io/ConfigurationExtensions.cs
+++ b/AngleSharp.Io/ConfigurationExtensions.cs
@@ -46,6 +46,8 @@
                 var service = new LoaderService(requesters);
                 return configuration.With(service);
             }
+
+            return configuration;
         }
     }
 }

--- a/AngleSharp.Io/ConfigurationExtensions.cs
+++ b/AngleSharp.Io/ConfigurationExtensions.cs
@@ -6,6 +6,7 @@
     using AngleSharp.Network.Default;
     using AngleSharp.Services;
     using System.Linq;
+    using System.Net.Http;
 
     /// <summary>
     /// Additional extensions for improved requesters.
@@ -27,6 +28,24 @@
             }
 
             return configuration;
+        }
+
+
+        /// <summary>
+        /// Adds a loader service that comes with all (improved) requesters.
+        /// </summary>
+        /// <param name="configuration">The configuration to use.</param>
+        /// <param name="httpMessageHandler">The HTTP handler stack to use for sending requests.</param>
+        /// <returns>The new configuration.</returns>
+        public static IConfiguration WithHttpRequesters(this IConfiguration configuration, HttpMessageHandler httpMessageHandler)
+        {
+            if (!configuration.Services.OfType<ILoaderService>().Any())
+            {
+                var httpClient = new HttpClient(httpMessageHandler);
+                var requesters = new IRequester[] { new HttpClientRequester(httpClient), new DataRequester() };
+                var service = new LoaderService(requesters);
+                return configuration.With(service);
+            }
         }
     }
 }


### PR DESCRIPTION
This method is used to inject HttpMessageHandler.
It allows mocking and unit tests for HttpClientListener.