### PR TITLE
Some changes in WithHttpClientRequesters method

### DIFF
--- a/AngleSharp.Io/ConfigurationExtensions.cs
+++ b/AngleSharp.Io/ConfigurationExtensions.cs
@@ -22,7 +22,7 @@
         {
             if (!configuration.Services.OfType<ILoaderService>().Any())
             {
-                var requesters = new IRequester [] { new HttpClientRequester(), new DataRequester() };
+                var requesters = new IRequester[] { new HttpClientRequester(), new DataRequester() };
                 var service = new LoaderService(requesters);
                 return configuration.With(service);
             }
@@ -35,13 +35,12 @@
         /// Adds a loader service that comes with all (improved) requesters.
         /// </summary>
         /// <param name="configuration">The configuration to use.</param>
-        /// <param name="httpMessageHandler">The HTTP handler stack to use for sending requests.</param>
+        /// <param name="httpClient">The HTTP client to use for requests.</param>
         /// <returns>The new configuration.</returns>
-        public static IConfiguration WithHttpRequesters(this IConfiguration configuration, HttpMessageHandler httpMessageHandler)
+        public static IConfiguration WithHttpClientRequesters(this IConfiguration configuration, HttpClient httpClient)
         {
             if (!configuration.Services.OfType<ILoaderService>().Any())
             {
-                var httpClient = new HttpClient(httpMessageHandler);
                 var requesters = new IRequester[] { new HttpClientRequester(httpClient), new DataRequester() };
                 var service = new LoaderService(requesters);
                 return configuration.With(service);

--- a/AngleSharp.Io/ConfigurationExtensions.cs
+++ b/AngleSharp.Io/ConfigurationExtensions.cs
@@ -20,14 +20,8 @@
         /// <returns>The new configuration.</returns>
         public static IConfiguration WithRequesters(this IConfiguration configuration)
         {
-            if (!configuration.Services.OfType<ILoaderService>().Any())
-            {
-                var requesters = new IRequester[] { new HttpClientRequester(), new DataRequester() };
-                var service = new LoaderService(requesters);
-                return configuration.With(service);
-            }
-
-            return configuration;
+            var httpClient = new HttpClient();
+            return configuration.WithHttpClientRequesters(httpClient);
         }
 
 

--- a/AngleSharp.Io/ConfigurationExtensions.cs
+++ b/AngleSharp.Io/ConfigurationExtensions.cs
@@ -9,16 +9,16 @@
     using System.Net.Http;
 
     /// <summary>
-    /// Additional extensions for improved requesters.
+    /// Additional extensions for using requesters.
     /// </summary>
     public static class ConfigurationExtensions
     {
         /// <summary>
-        /// Adds a loader service that comes with all (improved) requesters.
+        /// Adds a loader service that uses HttpClient Requester.
         /// </summary>
         /// <param name="configuration">The configuration to use.</param>
         /// <returns>The new configuration.</returns>
-        public static IConfiguration WithRequesters(this IConfiguration configuration)
+        public static IConfiguration WithHttpClientRequesters(this IConfiguration configuration)
         {
             var httpClient = new HttpClient();
             return configuration.WithHttpClientRequesters(httpClient);
@@ -26,7 +26,7 @@
 
 
         /// <summary>
-        /// Adds a loader service that comes with all (improved) requesters.
+        /// Adds a loader service that uses HttpClient Requester.
         /// </summary>
         /// <param name="configuration">The configuration to use.</param>
         /// <param name="httpClient">The HTTP client to use for requests.</param>


### PR DESCRIPTION
1. I think it would be better to pass the HttClient himself. It allows more flexibility.
2. make overload names consistent.